### PR TITLE
Bug Fixes and Rating Summary

### DIFF
--- a/client/src/RatingsAndReviews/RatingsAndReviews.jsx
+++ b/client/src/RatingsAndReviews/RatingsAndReviews.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import StaticStarList from './StaticStarList.jsx';
 import ReviewList from './ReviewList.jsx';
 import './css/MainContainer.css';
@@ -27,7 +27,7 @@ export default function RatingsAndReviews({id, reviewList}) {
         <div className="column2">
           <div className="blue-col">
             #of Reviews and Dropdown Menu
-            <ReviewList reviewList={reviewList} listCount={listCount} />
+            <ReviewList reviewList={reviewList} listCount={listCount} setListCount={setListCount} />
             <div className="review-list-buttons">
               <button
                 type="button"

--- a/client/src/RatingsAndReviews/RatingsAndReviews.jsx
+++ b/client/src/RatingsAndReviews/RatingsAndReviews.jsx
@@ -1,16 +1,34 @@
+/* eslint-disable import/extensions */
 import React, { useEffect } from 'react';
 import StaticStarList from './StaticStarList.jsx';
 import ReviewList from './ReviewList.jsx';
 import './css/MainContainer.css';
+import './css/RatingSummary.css';
 
 export default function RatingsAndReviews({id, reviewList}) {
   // Pass to Review List, which will render 2 reviews at a time
   // Need to use React.useState for testing purposes so that Jest can spyon this state
   const [listCount, setListCount] = React.useState(2);
+  const [ratingReturnVal, setRatingReturnVal] = React.useState(0);
+  const [recommendPercent, setRecommendPercent] = React.useState(0);
 
   function increaseReviewsSeen() {
     setListCount(listCount + 2);
   }
+
+  function returnAvgRating(avgRating) {
+    setRatingReturnVal(avgRating);
+  }
+
+  useEffect(() => {
+    const sumOfReviews = reviewList.length;
+    const numOfRecommend = reviewList.reduce((accum, review) => (
+      review.recommend ? accum + 1 : accum + 0
+    ), 0);
+    console.log('Number of recommended ', numOfRecommend);
+    const recommended = Math.floor((numOfRecommend / sumOfReviews) * 100);
+    setRecommendPercent(recommended);
+  }, [reviewList]);
 
   return (
     <div className="main-container" data-testid="rr-main">
@@ -18,8 +36,11 @@ export default function RatingsAndReviews({id, reviewList}) {
       <div className="row">
         <div className="column1">
           <div className="green-col">
-            Imagine a Big Number
-            <StaticStarList productId={id} />
+            <div className="rating-summary">
+              <div className="large-rating-number">{ratingReturnVal}</div>
+              <StaticStarList productId={id} returnAvgRating={returnAvgRating} />
+            </div>
+            <div className="percent">{`${recommendPercent}% of reviews recommend this product`}</div>
             Now Imagine a Graph
             And then some other bar guy for Characteristics
           </div>

--- a/client/src/RatingsAndReviews/ReviewList.jsx
+++ b/client/src/RatingsAndReviews/ReviewList.jsx
@@ -2,13 +2,19 @@ import React, { useState, useEffect } from 'react';
 import ReviewListCard from './ReviewListCard.jsx';
 import './css/ReviewList.css';
 
-export default function ReviewList({ reviewList, listCount }) {
+export default function ReviewList({ reviewList, listCount, setListCount }) {
   const [currentList, setCurrentList] = useState([]);
 
   useEffect(() => {
     const reviews = reviewList.slice(0, listCount);
     setCurrentList(reviews);
   }, [listCount]);
+
+  useEffect(() => {
+    // upon receiving a new reviewList, should render a new set of only 2
+    setCurrentList([]);
+    setListCount(2);
+  }, [reviewList]);
 
   return (
     <div className="review-list">

--- a/client/src/RatingsAndReviews/ReviewListCard.jsx
+++ b/client/src/RatingsAndReviews/ReviewListCard.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 import React from 'react';
 import dateFormat from 'dateformat';
 import StaticStarList from './StaticStarList.jsx';

--- a/client/src/RatingsAndReviews/ReviewPicture.jsx
+++ b/client/src/RatingsAndReviews/ReviewPicture.jsx
@@ -23,7 +23,7 @@ export default function ReviewPicture({src}) {
   if (src) {
     return (
       <>
-        <div className="thumbnail" style={style} onClick={toggleModal} data-testid="thumbnail"></div>
+        <img className="thumbnail" style={style} onClick={toggleModal} data-testid="thumbnail" alt=""/>
         {modal && (
           <ReviewModal toggleModal={toggleModal} img={src} />
         )}

--- a/client/src/RatingsAndReviews/StaticStarList.jsx
+++ b/client/src/RatingsAndReviews/StaticStarList.jsx
@@ -9,7 +9,7 @@ import StaticStar from './StaticStar.jsx';
 // Example: You want to use the stars to represent total reviews:
 // <StaticStarList productId={40344} /> <--ideally this is one we have useContext for
 
-export default function Stars({ productId, ratingInt }) {
+export default function Stars({ productId, ratingInt, returnAvgRating }) {
   const [rating, setRating] = useState(0);
 
   useEffect(() => {
@@ -21,6 +21,9 @@ export default function Stars({ productId, ratingInt }) {
           ), 0);
           const avRating = Math.round((ratingSum / results.data.results.length) * 10) / 10;
           setRating(avRating);
+          if (returnAvgRating) {
+            returnAvgRating(avRating);
+          }
         })
         .catch((err) => { throw err; });
     }

--- a/client/src/RatingsAndReviews/css/RatingSummary.css
+++ b/client/src/RatingsAndReviews/css/RatingSummary.css
@@ -1,0 +1,15 @@
+.rating-summary {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.large-rating-number {
+  font-size: 64px;
+  margin-right: 12px;
+}
+
+.percent {
+  font-size: 14px;
+  color: gray;
+  margin-bottom: 20px;
+}

--- a/client/src/RatingsAndReviews/css/ReviewList.css
+++ b/client/src/RatingsAndReviews/css/ReviewList.css
@@ -14,6 +14,7 @@
   flex-direction: column;
   justify-content: center;
   border-bottom: 2px solid gray;
+  word-break: break-all;
 }
 
 .card-top-row {
@@ -76,7 +77,7 @@
   margin: 15px 0 10px 10px;
 }
 
-.fa-check {
+.recommended .fa-check {
   top: 0; left: 0;
   margin-right: 5px;
   z-index: -1;

--- a/client/src/RatingsAndReviews/css/StaticStar.css
+++ b/client/src/RatingsAndReviews/css/StaticStar.css
@@ -1,9 +1,3 @@
-/* .star-box {
-  display: flex;
-  left: 10px;
-  margin-bottom: 10px;
-} */
-
 .empty-star,
 .half-star,
 .quarter-star,
@@ -49,49 +43,3 @@
   color: rgb(255, 191, 42);
   font-size: 0.75em;
 }
-
-/* Tutorial: https://jsfiddle.net/gonh06aL/2/ */
-/* Note to self: don't use react font awesome icons ever again. Perfecting this is an art within an art. Too many custom CSS variables and I am not about to learn how to create custom svg paths to clip backgrounds/shapes. Nope. */
-
-/* .half-star:after {
-  font-style: normal;
-  font-variant: normal;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  --fa-style-family: 'Font Awesome 5 Free';
-  content: '\f005';
-  position: absolute;
-  --fa-style: 900;
-  left: 0;
-  top: 0;
-  width: 50%;
-  overflow: hidden;
-  color: green;
-} */
-
-/* .star {
-  display: inline-block;
-  position: relative;
-  color: #ABAEB5;
-}
-.half-star::before {
-  content: '';
-  background-color: red;
-  width: 100px;
-  height: 100px;
-  position: absolute;
-}
-.half-star::after {
-  font-style: normal;
-  font-variant: normal;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  --fa-style-family: 'Font Awesome 5 Free';
-  --fa-style: 900;
-  --fa-content: '\f005';
-  position: absolute;
-  right: 50%;
-  --fa-primary-color: green;
-  --fa-stack-z-index: 10;
-  width: 50%;
-} */


### PR DESCRIPTION
Styling bug fix:
   Super long word from a product was expanding the review list cards way past their container size and were stretching the screen. Enabled a word-break word wrap to the CSS to fix.

More Reviews bug fix:
    The reviews list would update with new product id info, but only as long as "More Reviews" button was not clicked. When clicked, the review list correctly shows more reviews for the given product, but the reviews list was locked onto that product's review list only - changing a product id would no longer render a new review list.
    Additionally, when a new product was selected, the review list should have reverted back to displaying 2 reviews as a default, but was still rendering the amount that was set after clicking "More Reviews" x amount of times.
     Fixed with a useEffect to monitor any changes in review list and passed down a new prop setter to the reviews list component so that it could reset its list count.

Lefthand panel of Ratings and Reviews now displays a Rating Summary, which consists of:
A large number representing average views
Stars to visually represent average views
A percentage breakdown of how many reviews said they would recommend the product
